### PR TITLE
Make setsockopt argument bytes

### DIFF
--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -213,7 +213,7 @@ class PlanningClient(object):
             socket.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 2) # the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
             socket.setsockopt(zmq.TCP_KEEPALIVE_CNT, 2) # the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
             socket.connect('tcp://%s:%s' % (self.controllerIp, self.taskheartbeatport))
-            socket.setsockopt(zmq.SUBSCRIBE, '')
+            socket.setsockopt(zmq.SUBSCRIBE, b'')
             poller = zmq.Poller()
             poller.register(socket, zmq.POLLIN)
             


### PR DESCRIPTION
background: we allow installing mujinplanningclientpy to both Python2 and Python3..

setsockopt_string accepts unicode on Py2 while it accepts str on Py3.
setsockopt accepts str on Py2 while it accepts bytes on Py3.

so one of these are compatible:

- socket.setsockopt(zmq.SUBSCRIBE, b'')
- socket.setsockopt_string(zmq.SUBSCRIBE, u'')

maybe the first one is better as it does not change any code path on py2.