### PR TITLE
Add ZmqSubscriber.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.4 (2023-04-06)
+
+- Add `ZmqSubscriber`
+
+
 # 0.1.0 (2022-11-17)
 
 - Port from mujincontrollerclientpy

--- a/bin/mujin_planningclientpy_runshell.py
+++ b/bin/mujin_planningclientpy_runshell.py
@@ -29,7 +29,7 @@ def _Main():
     options = _ParseArguments()
     _ConfigureLogging(options.loglevel)
 
-    self = RealtimeRobotPlanningClient(options.url, options.username, options.password)
+    self = RealtimeRobotPlanningClient(controllerurl=options.url, controllerusername=options.username, controllerpassword=options.password)
 
     from IPython.terminal import embed
     ipshell = embed.InteractiveShellEmbed(config=embed.load_default_config())(local_ns=locals())

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -227,7 +227,7 @@ class PlanningClient(object):
     # Tasks related
     #
 
-    def ExecuteCommand(self, taskparameters, slaverequestid=None, timeout=None, fireandforget=None, respawnopts=None, checkpreempt=True):
+    def ExecuteCommand(self, taskparameters, slaverequestid=None, timeout=None, fireandforget=None, respawnopts=None, checkpreempt=True, forcereload=False):
         """Executes command with taskparameters via ZMQ.
 
         Args:
@@ -235,7 +235,8 @@ class PlanningClient(object):
             timeout (float): Timeout in seconds
             fireandforget (bool): Whether we should return immediately after sending the command. If True, return value is None.
             checkpreempt (bool): If a preempt function should be checked during execution.
-
+            forcereload (bool): If True, then force re-load the scene before executing the task
+        
         Returns:
             dict: Server response in JSON format. If fireandforget is True, then None.
         """
@@ -250,6 +251,7 @@ class PlanningClient(object):
                 'tasktype': self.tasktype,
                 'sceneparams': self._sceneparams,
                 'taskparameters': taskparameters,
+                'forcereload':forcereload,
             },
             'userinfo': self._userinfo,
             'slaverequestid': slaverequestid,

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -197,13 +197,16 @@ class PlanningClient(object):
         """
         if self._subscriber is None:
             self._subscriber = zmqsubscriber.ZmqSubscriber('tcp://%s:%d' % (self.controllerIp, self.taskheartbeatport or (self.taskzmqport + 1)), ctx=self._ctx)
-        return json.loads(self._subscriber.SpinOnce(timeout=timeout))
+        rawServerState = self._subscriber.SpinOnce(timeout=timeout)
+        if rawServerState is not None:
+            return json.loads(rawServerState)
+        return None
 
     def GetPublishedTaskState(self, timeout=2.0):
         """Return most recent published state. If publishing is disabled, then will return None
         """
         serverState = self.GetPublishedServerState(timeout=timeout)
-        if 'slavestates' in serverState:
+        if serverState is not None and 'slavestates' in serverState:
             return serverState['slavestates'].get('slaverequestid-%s' % self._slaverequestid)
         return None
     

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -190,7 +190,7 @@ class PlanningClient(object):
     def DeleteJobs(self, timeout=5):
         """Cancels all jobs"""
         if self._configsocket is not None:
-            self.SendConfig({'command': 'cancel'}, slaverequestid=self._slaverequestid, timeout=timeout, fireandforget=False)
+            self.SendConfig({'command': 'cancel'}, timeout=timeout, fireandforget=False)
 
     def GetPublishedTaskState(self, timeout=2.0):
         """Return most recent published state. If publishing is disabled, then will return None
@@ -262,7 +262,7 @@ class PlanningClient(object):
     # Config
     #
 
-    def Configure(self, configuration, timeout=None, fireandforget=None):
+    def Configure(self, configuration, timeout=None, fireandforget=None, slaverequestid=None):
         """Send a 'configure' command to the configsocket.
 
         Args:
@@ -274,9 +274,9 @@ class PlanningClient(object):
             dict: The 'output' field of the server response.
         """
         configuration['command'] = 'configure'
-        return self.SendConfig(configuration, timeout=timeout, fireandforget=fireandforget)
+        return self.SendConfig(configuration, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def SetLogLevel(self, componentLevels, fireandforget=None, timeout=5):
+    def SetLogLevel(self, componentLevels, fireandforget=None, slaverequestid=None, timeout=5):
         """Set planning log level.
 
         Args:
@@ -289,7 +289,7 @@ class PlanningClient(object):
             'command': 'setloglevel',
             'componentLevels': componentLevels
         }
-        return self.SendConfig(configuration, timeout=timeout, fireandforget=fireandforget)
+        return self.SendConfig(configuration, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
     def SendConfig(self, command, slaverequestid=None, timeout=None, fireandforget=None, checkpreempt=True):
         """Sends a config command via ZMQ to the planning server.
@@ -312,11 +312,11 @@ class PlanningClient(object):
     # Viewer Parameters Related
     #
 
-    def SetViewerFromParameters(self, viewerparameters, timeout=10, fireandforget=True, **kwargs):
+    def SetViewerFromParameters(self, viewerparameters, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         viewerparameters.update(kwargs)
-        return self.Configure({'viewerparameters': viewerparameters}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewerparameters': viewerparameters}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraZoomOut(self, zoommult=0.9, zoomdelta=20, timeout=10, fireandforget=True, ispan=True, **kwargs):
+    def MoveCameraZoomOut(self, zoommult=0.9, zoomdelta=20, timeout=10, fireandforget=True, ispan=True, slaverequestid=None, **kwargs):
         viewercommand = {
             'command': 'MoveCameraZoomOut',
             'zoomdelta': float(zoomdelta),
@@ -324,9 +324,9 @@ class PlanningClient(object):
             'ispan': bool(ispan)
         }
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraZoomIn(self, zoommult=0.9, zoomdelta=20, timeout=10, fireandforget=True, ispan=True, **kwargs):
+    def MoveCameraZoomIn(self, zoommult=0.9, zoomdelta=20, timeout=10, fireandforget=True, slaverequestid=None, ispan=True, **kwargs):
         viewercommand = {
             'command': 'MoveCameraZoomIn',
             'zoomdelta': float(zoomdelta),
@@ -334,9 +334,9 @@ class PlanningClient(object):
             'ispan': bool(ispan)
         }
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraLeft(self, ispan=True, panangle=5.0, pandelta=0.04, timeout=10, fireandforget=True, **kwargs):
+    def MoveCameraLeft(self, ispan=True, panangle=5.0, pandelta=0.04, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         viewercommand = {
             'command': 'MoveCameraLeft',
             'pandelta': float(pandelta),
@@ -344,9 +344,9 @@ class PlanningClient(object):
             'ispan': bool(ispan),
         }
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraRight(self, ispan=True, panangle=5.0, pandelta=0.04, timeout=10, fireandforget=True, **kwargs):
+    def MoveCameraRight(self, ispan=True, panangle=5.0, pandelta=0.04, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         viewercommand = {
             'command': 'MoveCameraRight',
             'pandelta': float(pandelta),
@@ -354,9 +354,9 @@ class PlanningClient(object):
             'ispan': bool(ispan),
         }
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraUp(self, ispan=True, angledelta=3.0, pandelta=0.04, timeout=10, fireandforget=True, **kwargs):
+    def MoveCameraUp(self, ispan=True, angledelta=3.0, pandelta=0.04, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         viewercommand = {
             'command': 'MoveCameraUp',
             'pandelta': float(pandelta),
@@ -364,9 +364,9 @@ class PlanningClient(object):
             'ispan': bool(ispan),
         }
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraDown(self, ispan=True, angledelta=3.0, pandelta=0.04, timeout=10, fireandforget=True, **kwargs):
+    def MoveCameraDown(self, ispan=True, angledelta=3.0, pandelta=0.04, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         viewercommand = {
             'command': 'MoveCameraDown',
             'pandelta': float(pandelta),
@@ -374,9 +374,9 @@ class PlanningClient(object):
             'ispan': bool(ispan),
         }
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def MoveCameraPointOfView(self, pointOfViewName, timeout=10, fireandforget=True, **kwargs):
+    def MoveCameraPointOfView(self, pointOfViewName, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         """
         Sends a command that moves the camera to one of the following point of view names:
         +x, -x, +y, -y, +z, -z.
@@ -387,9 +387,9 @@ class PlanningClient(object):
             'command': 'MoveCameraPointOfView',
             'axis': pointOfViewName,
         }
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def SetCameraTransform(self, pose=None, transform=None, distanceToFocus=0.0, timeout=10, fireandforget=True, **kwargs):
+    def SetCameraTransform(self, pose=None, transform=None, distanceToFocus=0.0, timeout=10, fireandforget=True, slaverequestid=None, **kwargs):
         """Sets the camera transform
         
         Args:
@@ -404,14 +404,14 @@ class PlanningClient(object):
         if pose is not None:
             viewercommand['pose'] = [float(f) for f in pose]
         viewercommand.update(kwargs)
-        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure({'viewercommand': viewercommand}, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def StartIPython(self, timeout=1, fireandforget=True, **kwargs):
+    def StartIPython(self, timeout=1, fireandforget=True, slaverequestid=None, **kwargs):
         configuration = {'startipython': True}
         configuration.update(kwargs)
-        return self.Configure(configuration, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure(configuration, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)
 
-    def StartRemotePDB(self, timeout=1, fireandforget=True, **kwargs):
+    def StartRemotePDB(self, timeout=1, fireandforget=True, slaverequestid=None, **kwargs):
         configuration = {'startremotepdb': True}
         configuration.update(kwargs)
-        return self.Configure(configuration, timeout=timeout, fireandforget=fireandforget)
+        return self.Configure(configuration, timeout=timeout, fireandforget=fireandforget, slaverequestid=slaverequestid)

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -192,12 +192,20 @@ class PlanningClient(object):
         if self._configsocket is not None:
             self.SendConfig({'command': 'cancel'}, timeout=timeout, fireandforget=False)
 
-    def GetPublishedTaskState(self, timeout=2.0):
+    def GetPublishedServerState(self, timeout=2.0):
         """Return most recent published state. If publishing is disabled, then will return None
         """
         if self._subscriber is None:
             self._subscriber = zmqsubscriber.ZmqSubscriber('tcp://%s:%d' % (self.controllerIp, self.taskheartbeatport or (self.taskzmqport + 1)), ctx=self._ctx)
         return json.loads(self._subscriber.SpinOnce(timeout=timeout))
+
+    def GetPublishedTaskState(self, timeout=2.0):
+        """Return most recent published state. If publishing is disabled, then will return None
+        """
+        serverState = self.GetPublishedServerState(timeout=timeout)
+        if 'slavestates' in serverState:
+            return serverState['slavestates'].get('slaverequestid-%s' % self._slaverequestid)
+        return None
     
     def SetScenePrimaryKey(self, scenepk):
         self.scenepk = scenepk

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -87,7 +87,6 @@ class PlanningClient(object):
     taskheartbeattimeout = None  # Seconds until reinitializing task's zmq server if no heartbeat is received, e.g. 7
 
     _subscriber = None # an instance of ZmqSubscriber
-    _subscription = None # the active subscription to taskheartbeatport
 
     def __init__(
         self,

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -158,9 +158,6 @@ class PlanningClient(object):
 
     def Destroy(self):
         self.SetDestroy()
-        if self._subscription is not None:
-            self._subscription.Unsubscribe()
-            self._subscription = None
         if self._subscriber is not None:
             self._subscriber.Destroy()
             self._subscriber = None
@@ -200,11 +197,8 @@ class PlanningClient(object):
         """Return most recent published state. If publishing is disabled, then will return None
         """
         if self._subscriber is None:
-            self._subscriber = zmqsubscriber.ZmqSubscriber(self._ctx)
-        if self._subscription is None:
-            self._subscription = self._subscriber.Subscribe('tcp://%s:%d' % (self.controllerIp, self.taskheartbeatport or (self.taskzmqport + 1)))
-        self._subscriber.SpinOnce(timeout=timeout)
-        return json.loads(self._subscription.message)
+            self._subscriber = zmqsubscriber.ZmqSubscriber('tcp://%s:%d' % (self.controllerIp, self.taskheartbeatport or (self.taskzmqport + 1)), ctx=self._ctx)
+        return json.loads(self._subscriber.SpinOnce(timeout=timeout))
     
     def SetScenePrimaryKey(self, scenepk):
         self.scenepk = scenepk

--- a/python/mujinplanningclient/realtimeitl3planningclient.py
+++ b/python/mujinplanningclient/realtimeitl3planningclient.py
@@ -252,21 +252,6 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
-    def PlotContacts(self, report={}, timeout=1, fireandforget=True, **kwargs):
-        """
-
-        Args:
-            report (dict, optional):
-            timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 1)
-            fireandforget (bool, optional): If True, does not wait for the command to finish. The method returns immediately and the command remains queued on the server.
-        """
-        taskparameters = {
-            'command': 'PlotContacts',
-            'report': report
-        }
-        taskparameters.update(kwargs)
-        return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
-
     def PopulateTargetInContainer(self, locationName, populateTargetUri, populateFnName, containerMetaData=None, timeout=20, **kwargs):
         """Populates targets in container using populateFn.
 

--- a/python/mujinplanningclient/realtimerobotplanningclient.py
+++ b/python/mujinplanningclient/realtimerobotplanningclient.py
@@ -80,7 +80,7 @@ class RealtimeRobotPlanningClient(planningclient.PlanningClient):
         """
         self._robotaccelmult = robotaccelmult
 
-    def ExecuteCommand(self, taskparameters, robotname=None, toolname=None, robotspeed=None, robotaccelmult=None, envclearance=None, timeout=10, fireandforget=False, respawnopts=None):
+    def ExecuteCommand(self, taskparameters, robotname=None, toolname=None, robotspeed=None, robotaccelmult=None, envclearance=None, timeout=10, fireandforget=False, respawnopts=None, forcereload=False):
         """Wrapper to ExecuteCommand with robot info specified in taskparameters.
 
         Executes a command in the task.
@@ -139,7 +139,7 @@ class RealtimeRobotPlanningClient(planningclient.PlanningClient):
             if envclearance is not None:
                 taskparameters['envclearance'] = envclearance
 
-        return super(RealtimeRobotPlanningClient, self).ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget, respawnopts=respawnopts)
+        return super(RealtimeRobotPlanningClient, self).ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget, respawnopts=respawnopts, forcereload=forcereload)
 
     def GetJointValues(self, timeout=10, **kwargs):
         """Gets the current robot joint values

--- a/python/mujinplanningclient/version.py
+++ b/python/mujinplanningclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinplanningclient/version.py
+++ b/python/mujinplanningclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinplanningclient/zmqsubscriber.py
+++ b/python/mujinplanningclient/zmqsubscriber.py
@@ -73,14 +73,20 @@ class ZmqSubscriber(object):
         self._ctx = None
 
     def _HandleReceivedMessage(self, message, endpoint, elapsedTime):
+        """Call the user callback when message is received.
+        """
         if self._callbackFn:
             self._callbackFn(message=message, endpoint=endpoint, elapsedTime=elapsedTime)
 
     def _HandleTimeout(self, endpoint, elapsedTime):
+        """Call the user callback when subscription timed out.
+        """
         if self._callbackFn:
             self._callbackFn(message=None, endpoint=endpoint, elapsedTime=elapsedTime)
 
     def _HandleNotConfigured(self):
+        """Call the user callback when getEndpointFn() returns None, disabling the subscription temporarily.
+        """
         if self._callbackFn:
             self._callbackFn(message=None, endpoint=None, elapsedTime=0)
 

--- a/python/mujinplanningclient/zmqsubscriber.py
+++ b/python/mujinplanningclient/zmqsubscriber.py
@@ -197,10 +197,10 @@ class ZmqSubscriber(object):
             # poll what is left
             try:
                 for subscription in subscriptions:
-                    if subscription is not None and subscription._socket is not None:
+                    if subscription is not None:
                         self._poller.register(subscription._socket, zmq.POLLIN)
                 self._poller.poll(20) # poll a little and try again
             finally:
                 for subscription in subscriptions:
-                    if subscription is not None and subscription._socket is not None:
+                    if subscription is not None:
                         self._poller.unregister(subscription._socket)

--- a/python/mujinplanningclient/zmqsubscriber.py
+++ b/python/mujinplanningclient/zmqsubscriber.py
@@ -67,6 +67,11 @@ class ZmqSubscriber(object):
         """
         return self._endpoint
 
+    def SetEndpoint(self, endpoint):
+        """Update endpoint for subscription
+        """
+        self._endpoint = endpoint
+
     def Destroy(self):
         self._CloseSocket()
         if self._ctxown is not None:
@@ -126,8 +131,10 @@ class ZmqSubscriber(object):
         # check and see if endpoint has changed
         if self._getEndpointFn is not None:
             self._endpoint = self._getEndpointFn()
-        if self._socket is not None and self._socketEndpoint != self._endpoint:
-            log.debug('subscription endpoint changed "%s" -> "%s", so closing previous subscription socket', self._socketEndpoint, self._endpoint)
+
+        endpoint = self._endpoint
+        if self._socket is not None and self._socketEndpoint != endpoint:
+            log.debug('subscription endpoint changed "%s" -> "%s", so closing previous subscription socket', self._socketEndpoint, endpoint)
             self._CloseSocket()
 
     def SpinOnce(self, timeout=None, checkpreemptfn=None):
@@ -149,8 +156,9 @@ class ZmqSubscriber(object):
             now = GetMonotonicTime()
 
             # ensure socket
-            if self._endpoint is not None and self._socket is None:
-                self._OpenSocket(self._endpoint)
+            endpoint = self._endpoint
+            if endpoint is not None and self._socket is None:
+                self._OpenSocket(endpoint)
                 self._lastReceivedTimestamp = starttime
 
             # loop to get all received message and only process the last one
@@ -173,8 +181,9 @@ class ZmqSubscriber(object):
                 if now - self._lastReceivedTimestamp > self._timeout:
                     log.debug('have not received message on subscription socket for endpoint "%s" in %.03f seconds, closing socket and re-creating', self._socketEndpoint, now - self._lastReceivedTimestamp)
                     self._CloseSocket()
-                    if self._endpoint is not None:
-                        self._OpenSocket(self._endpoint)
+                    endpoint = self._endpoint
+                    if endpoint is not None:
+                        self._OpenSocket(endpoint)
                         self._lastReceivedTimestamp = now
 
             if timeout is None:

--- a/python/mujinplanningclient/zmqsubscriber.py
+++ b/python/mujinplanningclient/zmqsubscriber.py
@@ -12,6 +12,8 @@ import logging
 log = logging.getLogger(__name__)
 
 class ZmqSubscription(object):
+    """Subscription handle holding an active ongoing subscription. Call `ZmqSubscriber.Subscribe()` to get an instance.
+    """
 
     _subscriber = None # weakref to ZmqSubscriber
     _socket = None # zmq socket
@@ -77,6 +79,8 @@ class ZmqSubscription(object):
         return False
 
 class ZmqSubscriber(object):
+    """Subscriber that can handle multiple ongoing subscriptions.
+    """
 
     _ctx = None # zmq context
     _ctxown = None # created zmq context
@@ -111,7 +115,15 @@ class ZmqSubscriber(object):
         self._ctx = None
 
     def Subscribe(self, endpoint, callbackFn, timeout=4.0):
-        """Subscribe to zmq endpoint
+        """Subscribe to zmq endpoint.
+
+        Args:
+            endpoint: the zmq endpoint string to subscribe to
+            callbackFn: the function to call when subscription receives latest message, it is up to the caller to decode the raw zmq message received, the arguments for the callback function are (ZmqSubscription, rawMessage)
+            timeout: number of seconds, after this duration, the subscription socket is considered dead and will be recreated automatically to handle network changes (Default: 4.0)
+
+        Returns:
+            ZmqSubscription: call ZmqSubscription.Unsubscribe() to stop the subscription
         """
         subscription = ZmqSubscription()
         subscription._timeout = timeout
@@ -123,6 +135,9 @@ class ZmqSubscriber(object):
 
     def Unsubscribe(self, subscription):
         """Stop a subscription.
+
+        Args:
+            subscription: the ZmqSubscription instance to stop subscribing
         """
         if subscription in self._subscriptions:
             self._subscriptions.remove(subscription)
@@ -131,6 +146,10 @@ class ZmqSubscriber(object):
 
     def SpinOnce(self, timeout=None, checkpreemptfn=None):
         """Spin all subscription once, ensure that each subscription is received at least once. Block up to supplied timeout duration. If timeout is None, then receive what we can receive without blocking or raising any timeout error.
+
+        Args:
+            timeout: If not None, will raise TimeoutError if not all subscriptions can be handled in time. If None, then receive what we can receive without blocking or raising TimeoutError.
+            checkpreemptfn: The function that for checking for preemptions
         """
         starttime = GetMonotonicTime()
 

--- a/python/mujinplanningclient/zmqsubscriber.py
+++ b/python/mujinplanningclient/zmqsubscriber.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2012-2023 MUJIN Inc
+
+import weakref
+
+from . import _
+from . import zmq
+from . import GetMonotonicTime
+from . import TimeoutError
+
+import logging
+log = logging.getLogger(__name__)
+
+class ZmqSubscription(object):
+
+    _subscriber = None # weakref to ZmqSubscriber
+    _socket = None # zmq socket
+    _lastReceivedTimestamp = 0 # when message was last received on this subscription
+
+    _endpoint = None # zmq subscription endpoint
+    _callbackFn = None # function to call back when new message is received on the subscription socket
+    _timeout = 4.0 # beyond this number of seconds, the socket is considered dead and should be recreated
+
+    def __del__(self):
+        self.Unsubscribe()
+
+    def Unsubscribe(self):
+        """Stop the subscription.
+        """
+        if self._subscriber:
+            self._subscriber.Unsubscribe(self)
+            self._subscriber = None
+        self._CloseSocket()
+
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    def _EnsureSocket(self, ctx, now):
+        if self._socket:
+            return
+        socket = ctx.socket(zmq.SUB)
+        socket.setsockopt(zmq.CONFLATE, 1) # store only newest message. have to call this before connect
+        socket.setsockopt(zmq.TCP_KEEPALIVE, 1) # turn on tcp keepalive, do these configuration before connect
+        socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 2) # the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further
+        socket.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 2) # the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime
+        socket.setsockopt(zmq.TCP_KEEPALIVE_CNT, 2) # the number of unacknowledged probes to send before considering the connection dead and notifying the application layer
+        socket.connect(self._endpoint)
+        socket.setsockopt(zmq.SUBSCRIBE, b'') # have to use b'' to make python3 compatible
+        self._socket = socket
+        self._lastReceivedTimestamp = now
+
+    def _CloseSocket(self):
+        if self._socket:
+            try:
+                self._socket.close()
+            except Exception as e:
+                log.exception('failed to close subscription socket for endpoint "%s": %s', self._endpoint, e)
+        self._socket = None
+
+    def _TryReceiveOnce(self, now):
+        message = None
+        # loop to get all received message and only process the last one
+        while True:
+            try:
+                message = self._socket.recv(zmq.NOBLOCK)
+            except zmq.ZMQError as e:
+                if e.errno != zmq.EAGAIN:
+                    log.exception('caught exception while trying to receive from subscription socket for endpoint "%s": %s', self._endpoint, e)
+                    self._CloseSocket()
+                    raise
+                break # got EAGAIN, so break
+        if message is not None:
+            self._lastReceivedTimestamp = now
+            self._callbackFn(self, message)
+            return True
+        return False
+
+class ZmqSubscriber(object):
+
+    _ctx = None # zmq context
+    _ctxown = None # created zmq context
+    _poller = None # zmq poller
+
+    _subscriptions = None # a list of ZmqSubscription
+
+    def __init__(self, ctx=None):
+        self._subscriptions = []
+
+        self._ctx = ctx
+        if self._ctx is None:
+            self._ctxown = zmq.Context()
+            self._ctx = self._ctxown
+
+        self._poller = zmq.Poller()
+
+    def __del__(self):
+        self.Destroy()
+
+    def Destroy(self):
+        for subscription in self._subscriptions:
+            subscription._subscriber = None
+            subscription._CloseSocket()
+        self._subscriptions = []
+        if self._ctxown is not None:
+            try:
+                self._ctxown.destroy()
+            except Exception as e:
+                log.exception('caught exception when destroying zmq context: %s', e)
+            self._ctxown = None
+        self._ctx = None
+
+    def Subscribe(self, endpoint, callbackFn, timeout=4.0):
+        """Subscribe to zmq endpoint
+        """
+        subscription = ZmqSubscription()
+        subscription._timeout = timeout
+        subscription._endpoint = endpoint
+        subscription._callbackFn = callbackFn
+        subscription._subscriber = weakref.proxy(self)
+        self._subscriptions.append(subscription)
+        return subscription
+
+    def Unsubscribe(self, subscription):
+        """Stop a subscription.
+        """
+        if subscription in self._subscriptions:
+            self._subscriptions.remove(subscription)
+        subscription._subscriber = None
+        subscription._CloseSocket()
+
+    def SpinOnce(self, timeout=None, checkpreemptfn=None):
+        """Spin all subscription once, ensure that each subscription is received at least once. Block up to supplied timeout duration. If timeout is None, then receive what we can receive without blocking or raising any timeout error.
+        """
+        starttime = GetMonotonicTime()
+
+        # make a list of the subscriptions, we will mark them done as we receive messages on them
+        subscriptions = list(self._subscriptions)
+        for subscription in subscriptions:
+            subscription._EnsureSocket(self._ctx, starttime)
+
+        while True:
+            now = GetMonotonicTime()
+
+            # try receive for each subscription
+            for index, subscription in enumerate(subscriptions):
+                if subscription is not None:
+                    if subscription._TryReceiveOnce(now):
+                        subscriptions[index] = None # already done
+
+            # re-create timed out sockets
+            for subscription in subscriptions:
+                if subscription:
+                    if now - subscription._lastReceivedTimestamp > subscription._timeout:
+                        subscription._CloseSocket()
+            for subscription in subscriptions:
+                if subscription:
+                    subscription._EnsureSocket(self._ctx, now)
+
+            if timeout is None:
+                return
+
+            # check if all subscriptions have received at least once
+            hasPendingSubscription = False
+            for subscription in subscriptions:
+                if subscription is not None:
+                    hasPendingSubscription = True
+                    break
+            if not hasPendingSubscription:
+                return
+
+            # check for timeout
+            if now - starttime > timeout:
+                raise TimeoutError(_('Timed out waiting for subscriptions'))
+            if checkpreemptfn:
+                checkpreemptfn()
+
+            # poll what is left
+            try:
+                for subscription in subscriptions:
+                    if subscription is not None and subscription._socket is not None:
+                        self._poller.register(subscription._socket, zmq.POLLIN)
+                self._poller.poll(20) # poll a little and try again
+            finally:
+                for subscription in subscriptions:
+                    if subscription is not None and subscription._socket is not None:
+                        self._poller.unregister(subscription._socket)

--- a/python/mujinplanningclient/zmqsubscriber.py
+++ b/python/mujinplanningclient/zmqsubscriber.py
@@ -200,9 +200,9 @@ class ZmqThreadedSubscriber(ZmqSubscriber):
     _thread = None # a background thread for handling subscription
     _stopThread = False # flag to preempt the background thread
 
-    def __init__(self, endpoint, callbackFn=None, timeout=4.0, ctx=None, checkpreemptfn=None, threadName='zmqSubscriber'):
+    def __init__(self, endpoint=None, getEndpointFn=None, callbackFn=None, timeout=4.0, ctx=None, checkpreemptfn=None, threadName='zmqSubscriber'):
         self._threadName = threadName
-        super(ZmqThreadedSubscriber, self).__init__(endpoint, callbackFn=callbackFn, timeout=timeout, ctx=ctx, checkpreemptfn=checkpreemptfn)
+        super(ZmqThreadedSubscriber, self).__init__(endpoint=endpoint, getEndpointFn=getEndpointFn, callbackFn=callbackFn, timeout=timeout, ctx=ctx, checkpreemptfn=checkpreemptfn)
 
         self._StartSubscriberThread()
 


### PR DESCRIPTION
Example usage:

```python
subscriber = zmqsubscriber.ZmqSubscriber('tcp://localhost:7002')
message = subscriber.SpinOnce(timeout=2.0)
state = json.loads(message)
subscriber.Destroy()
```

1. `Subscribe` can optionally pass in callback function to be called during `SpinOnce()` when socket receives message
2. `SpinOnce` ensures each subscription is received at least once, or raise timeout
3. If `timeout` is `None`, then we receive as much as we can without blocking
4. caller can check if `endpoint` is up-to-date and decide to `Unsubscribe` and re-`Subscribe` with new endpoint
5. if a socket has not received for a while, we automatically re-create in the background
