### PR TITLE
Provide webstack password to the planning server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Pass webstack password to planning server.
 
+
 # 0.1.4 (2023-04-06)
 
 - Add `ZmqSubscriber`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.6 (2023-05-17)
+
+- Pass webstack password to planning server.
+
 # 0.1.4 (2023-04-06)
 
 - Add `ZmqSubscriber`

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -135,6 +135,7 @@ class PlanningClient(object):
 
         self._userinfo = {
             'username': self.controllerusername,
+            'password': self.controllerpassword,
             'locale': os.environ.get('LANG', ''),
         }
 

--- a/python/mujinplanningclient/version.py
+++ b/python/mujinplanningclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
Provide webstack password to the planning server. The planning server need this in order to upload logs to webstack.