### PR TITLE
fix typo in controllerIp initialization

### DIFF
--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -127,7 +127,7 @@ class PlanningClient(object):
         self.tasktype = tasktype
 
         if controllerip:
-            self.contrllerIp = controllerip
+            self.controllerIp = controllerip
             self.controllerusername = controllerusername
             self.controllerpassword = controllerpassword
         else:


### PR DESCRIPTION
Passing controllerip could not initialize self.controllerIp correctly.

/cc @ntohge