### PR TITLE
Fix SetLogLevel call in planningclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.6 (2023-06-09)
+
+- Fix `SetLogLevel` call in planningclient
+
 # 0.1.4 (2023-04-06)
 
 - Add `ZmqSubscriber`

--- a/python/mujinplanningclient/planningclient.py
+++ b/python/mujinplanningclient/planningclient.py
@@ -306,7 +306,6 @@ class PlanningClient(object):
                                 If component name is empty string, it sets the root logger.
                                 If level name is empty string, it unsets the level previously set.
         """
-        super(PlanningClient, self).SetLogLevel(componentLevels, timeout=timeout)
         configuration = {
             'command': 'setloglevel',
             'componentLevels': componentLevels

--- a/python/mujinplanningclient/version.py
+++ b/python/mujinplanningclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
Fixes `SetLogLevel` call trying to call super when `PlanningClient` inherits from `object`