### PR TITLE
refactor: Finish refactoring of HandEyeClient

### DIFF
--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
     """Mujin planning client for the HandEyeCalibration task"""
 
-    tasktype='handeyecalibration',
+    tasktype = 'handeyecalibration',
 
     _deprecated = None # used to mark arguments as deprecated (set argument default value to this)
 

--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -23,6 +23,10 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
     def __init__(
         self,
         robotname,
+        robotspeed=None,
+        robotaccelmult=None,
+        envclearance=10.0,
+        robotBridgeConnectionInfo=None, 
         taskzmqport=11000,
         taskheartbeatport=11001,
         taskheartbeattimeout=7.0,
@@ -41,7 +45,11 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
         """Connects to the Mujin controller, initializes HandEyeCalibration task and sets up parameters
 
         Args:
-            robotname (str): Name of the robot, e.g. VP-5243I
+            robotname (str, optional): Name of the robot, e.g. VP-5243I
+            robotspeed (float, optional): Speed of the robot, e.g. 0.4
+            robotaccelmult (float, optional): Optional multiplier for the robot acceleration.
+            envclearance (float, optional): Environment clearance in millimeter, e.g. 20
+            robotBridgeConnectionInfo (str, optional): dict holding the connection info for the robot bridge.
             taskzmqport (int, optional): Port of the task's ZMQ server, e.g. 7110. (Default: 11000)
             taskheartbeatport (int, optional): Port of the task's ZMQ server's heartbeat publisher, e.g. 7111. (Default: 11001)
             taskheartbeattimeout (float, optional): Seconds until reinitializing task's ZMQ server if no heartbeat is received, e.g. 7
@@ -58,6 +66,10 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
         """
         super(HandEyeCalibrationPlanningClient, self).__init__(
             robotname=robotname,
+            robotspeed=robotspeed,
+            robotaccelmult=robotaccelmult,
+            envclearance=envclearance,
+            robotBridgeConnectionInfo=robotBridgeConnectionInfo,
             taskzmqport=taskzmqport,
             taskheartbeatport=taskheartbeatport,
             taskheartbeattimeout=taskheartbeattimeout,

--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -57,6 +57,7 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
             ignoredArgs: Additional keyword args are not used, but allowed for easy initialization from a dictionary
         """
         super(HandEyeCalibrationPlanningClient, self).__init__(
+            robotname=robotname,
             taskzmqport=taskzmqport,
             taskheartbeatport=taskheartbeatport,
             taskheartbeattimeout=taskheartbeattimeout,

--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -5,9 +5,9 @@
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Tuple, Union # noqa: F401 # used in type check
+    from . import zmq
 
 # mujin imports
-from . import zmq
 from . import planningclient
 
 # logging

--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
     """Mujin planning client for the HandEyeCalibration task"""
 
-    tasktype = 'handeyecalibration',
+    tasktype = 'handeyecalibration'
 
     _deprecated = None # used to mark arguments as deprecated (set argument default value to this)
 

--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -18,6 +18,8 @@ log = logging.getLogger(__name__)
 class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
     """Mujin planning client for the HandEyeCalibration task"""
 
+    tasktype='handeyecalibration',
+
     _deprecated = None # used to mark arguments as deprecated (set argument default value to this)
 
     def __init__(
@@ -30,7 +32,6 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
         taskzmqport=11000,
         taskheartbeatport=11001,
         taskheartbeattimeout=7.0,
-        tasktype='handeyecalibration',
         ctx=None,
         slaverequestid=None,
         controllerip='',
@@ -41,7 +42,7 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
         callerid='',
         **ignoredArgs
     ):
-        # type: (str, int, int, float, str, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
+        # type: (str, Optional[float], Optional[float], float, Optional[str], int, int, float, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
         """Connects to the Mujin controller, initializes HandEyeCalibration task and sets up parameters
 
         Args:
@@ -53,7 +54,6 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
             taskzmqport (int, optional): Port of the task's ZMQ server, e.g. 7110. (Default: 11000)
             taskheartbeatport (int, optional): Port of the task's ZMQ server's heartbeat publisher, e.g. 7111. (Default: 11001)
             taskheartbeattimeout (float, optional): Seconds until reinitializing task's ZMQ server if no heartbeat is received, e.g. 7
-            tasktype (str, optional): Type of the task, e.g. 'binpicking', 'handeyecalibration', 'itlrealtimeplanning3'. Default: handeyecalibration
             ctx (zmq.Context, optional): Seconds until reinitializing task's ZMQ server if no heartbeat is received, e.g. 7
             slaverequestid:
             controllerip (str): IP or hostname of the mujin controller, e.g. 172.17.0.2 or controller123
@@ -73,7 +73,7 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
             taskzmqport=taskzmqport,
             taskheartbeatport=taskheartbeatport,
             taskheartbeattimeout=taskheartbeattimeout,
-            tasktype=tasktype,
+            tasktype=self.tasktype,
             ctx=ctx,
             slaverequestid=slaverequestid,
             controllerip=controllerip,


### PR DESCRIPTION
Explicitly pass parameters instead of using kwags and add type annotations.

We're removing kwargs since these arguments are the only ones that the underlying planningclient accepts, and the function signature is uninformative otherwise.