### PR TITLE
refactor: Finish refactoring of RealTimeITL3PlanningClient

### DIFF
--- a/python/mujinplanningclient/realtimeitl3planningclient.py
+++ b/python/mujinplanningclient/realtimeitl3planningclient.py
@@ -19,6 +19,8 @@ log = logging.getLogger(__name__)
 class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanningClient):
     """Mujin planning client for the RealtimeITL3 task"""
 
+    tasktype = 'realtimeitl3'
+
     _deprecated = None # used to mark arguments as deprecated (set argument default value to this)
 
     def __init__(
@@ -31,7 +33,6 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         taskzmqport=11000,
         taskheartbeatport=11001,
         taskheartbeattimeout=7.0,
-        tasktype='realtimeitl3',
         ctx=None,
         slaverequestid=None,
         controllerip='',
@@ -42,7 +43,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         callerid='',
         **ignoredArgs
     ):
-        # type: (str, Optional[float], Optional[float], float, Optional[str], int, int, float, str, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
+        # type: (str, Optional[float], Optional[float], float, Optional[str], int, int, float, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
         """Connects to the Mujin controller, initializes RealtimeITL3 task and sets up parameters
 
         Args:
@@ -54,7 +55,6 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             taskzmqport (int, optional): Port of the task's ZMQ server, e.g. 7110. (Default: 11000)
             taskheartbeatport (int, optional): Port of the task's ZMQ server's heartbeat publisher, e.g. 7111. (Default: 11001)
             taskheartbeattimeout (float, optional): Seconds until reinitializing task's ZMQ server if no heartbeat is received, e.g. 7
-            tasktype (str, optional): Type of the task, e.g. 'binpicking', 'handeyecalibration', 'itlrealtimeplanning3'. Default: realtimeitl3
             ctx (zmq.Context, optional): Seconds until reinitializing task's ZMQ server if no heartbeat is received, e.g. 7
             slaverequestid:
             controllerip (str): IP or hostname of the mujin controller, e.g. 172.17.0.2 or controller123
@@ -75,7 +75,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             taskzmqport=taskzmqport,
             taskheartbeatport=taskheartbeatport,
             taskheartbeattimeout=taskheartbeattimeout,
-            tasktype=tasktype,
+            tasktype=self.tasktype,
             ctx=ctx,
             slaverequestid=slaverequestid,
             controllerip=controllerip,
@@ -125,6 +125,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
+    # TODO: Determine actual types of the arguments instead of using Any.
     def ExecuteTrajectory(self, identifier, trajectories, statevalues=None, stepping=False, istep=None, cycles=1, restorevalues=None, envclearance=15, robotspeed=None, robotaccelmult=None, timeout=10, fireandforget=False):
         # type: (Any, Any, Any, Any, Any, Any, Any, float, Optional[float], Optional[float], float, bool) -> Any
         """

--- a/python/mujinplanningclient/realtimeitl3planningclient.py
+++ b/python/mujinplanningclient/realtimeitl3planningclient.py
@@ -2,7 +2,13 @@
 # Copyright (C) 2017 MUJIN Inc.
 # Mujin planning client for ITL task (v3)
 
+# system imports
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing import Any, Dict, List, Optional, Tuple, Union # noqa: F401 # used in type check
+
 # mujin imports
+from . import zmq
 from . import realtimerobotplanningclient
 
 # logging
@@ -15,7 +21,28 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
 
     _deprecated = None # used to mark arguments as deprecated (set argument default value to this)
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        robotname='',
+        robotspeed=None,
+        robotaccelmult=None,
+        envclearance=10.0,
+        robotBridgeConnectionInfo=None,
+        taskzmqport=11000,
+        taskheartbeatport=11001,
+        taskheartbeattimeout=7.0,
+        tasktype='realtimeitl3',
+        ctx=None,
+        slaverequestid=None,
+        controllerip='',
+        controllerurl='',
+        controllerusername='',
+        controllerpassword='',
+        scenepk='',
+        callerid='',
+        **ignoredArgs
+    ):
+        # type: (str, Optional[float], Optional[float], float, Optional[str], int, int, float, str, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
         """Connects to the Mujin controller, initializes RealtimeITL3 task and sets up parameters
 
         Args:
@@ -38,9 +65,35 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             callerid (str, optional): Caller identifier to send to server on every command
             ignoredArgs: Additional keyword args are not used, but allowed for easy initialization from a dictionary
         """
-        super(RealtimeITL3PlanningClient, self).__init__(tasktype='realtimeitlplanning3', **kwargs)
+        
+        super(RealtimeITL3PlanningClient, self).__init__(
+            robotname=robotname,
+            robotspeed=robotspeed,
+            robotaccelmult=robotaccelmult,
+            envclearance=envclearance,
+            robotBridgeConnectionInfo=robotBridgeConnectionInfo,
+            taskzmqport=taskzmqport,
+            taskheartbeatport=taskheartbeatport,
+            taskheartbeattimeout=taskheartbeattimeout,
+            tasktype=tasktype,
+            ctx=ctx,
+            slaverequestid=slaverequestid,
+            controllerip=controllerip,
+            controllerurl=controllerurl,
+            controllerusername=controllerusername,
+            controllerpassword=controllerpassword,
+            scenepk=scenepk,
+            callerid=callerid
+        )
+
+
+    #
+    # Commands
+    #
+
 
     def SetJointValues(self, jointvalues, robotname=None, timeout=10, **kwargs):
+        # type: (List[float], Optional[str], float, Any) -> Any
         """
         Args:
             jointvalues (list[float]):
@@ -50,13 +103,14 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         taskparameters = {
             'command': 'SetJointValues',
             'jointvalues': jointvalues,
-        }
+        }  # type: Dict[str, Any]
         if robotname is not None:
             taskparameters['robotname'] = robotname
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout)
 
     def GetITLState(self, robotname=None, timeout=10, fireandforget=False, **kwargs):
+        # type: (Optional[str], float, bool, Any) -> Any
         """
         Args:
             robotname (str, optional): Name of the robot
@@ -65,13 +119,14 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         """
         taskparameters = {
             'command': 'GetITLState',
-        }
+        }  # type: Dict[str, Any]
         if robotname is not None:
             taskparameters['robotname'] = robotname
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def ExecuteTrajectory(self, identifier, trajectories, statevalues=None, stepping=False, istep=None, cycles=1, restorevalues=None, envclearance=15, robotspeed=None, robotaccelmult=None, timeout=10, fireandforget=False):
+        # type: (Any, Any, Any, Any, Any, Any, Any, float, Optional[float], Optional[float], float, bool) -> Any
         """
         Args:
             identifier:
@@ -94,7 +149,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             'stepping': stepping,
             'cycles': cycles,
             'envclearance': envclearance,
-        }
+        }  # type: Dict[str, Any]
         if statevalues is not None:
             taskparameters['statevalues'] = statevalues
         if istep is not None:
@@ -108,6 +163,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def ExecuteTrajectoryStep(self, reverse=False, envclearance=15, robotspeed=None, robotaccelmult=None, timeout=10, fireandforget=False):
+        # type: (bool, float, Optional[float], Optional[float], float, bool) -> Any
         """
         Args:
             reverse (bool, optional): (Default: False)
@@ -121,7 +177,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             'command': 'ExecuteTrajectoryStep',
             'reverse': reverse,
             'envclearance': envclearance,
-        }
+        }  # type: Dict[str, Any]
         if robotspeed is not None:
             taskparameters['robotspeed'] = robotspeed
         if robotaccelmult is not None:
@@ -129,6 +185,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def PauseExecuteTrajectory(self, timeout=10, fireandforget=False):
+        # type: (float, bool) -> Any
         """
         Args:
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
@@ -136,10 +193,11 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         """
         taskparameters = {
             'command': 'PauseExecuteTrajectory',
-        }
+        }  # type: Dict[str, Any]
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def ResumeExecuteTrajectory(self, timeout=10, fireandforget=False):
+        # type: (float, bool) -> Any
         """
         Args:
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
@@ -147,10 +205,11 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         """
         taskparameters = {
             'command': 'ResumeExecuteTrajectory',
-        }
+        }  # type: Dict[str, Any]
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def ComputeRobotConfigsForCommandVisualization(self, executiongraph, commandindex=0, timeout=2, fireandforget=False, **kwargs):
+        # type: (Any, Any, float, bool, Any) -> Any
         """
         Args:
             executiongraph:
@@ -162,11 +221,12 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             'command': 'ComputeRobotConfigsForCommandVisualization',
             'executiongraph': executiongraph,
             'commandindex': commandindex,
-        }
+        }  # type: Dict[str, Any]
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def ComputeRobotJointValuesForCommandVisualization(self, program, commandindex=0, timeout=2, fireandforget=False, **kwargs):
+        # type: (Any, Any, float, bool, Any) -> Any
         """
         Args:
             program:
@@ -178,11 +238,12 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             'command': 'ComputeRobotJointValuesForCommandVisualization',
             'program': program,
             'commandindex': commandindex,
-        }
+        }  # type: Dict[str, Any]
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def PlotProgramWaypoints(self, timeout=1, fireandforget=True, **kwargs):
+        # type: (float, bool, Any) -> Any
         """
         Args:
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 1)
@@ -190,11 +251,12 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         """
         taskparameters = {
             'command': 'PlotProgramWaypoints',
-        }
+        }  # type: Dict[str, Any]
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def StartITLProgram(self, programName, robotspeed=None, robotaccelmult=None, timeout=10, fireandforget=False, **kwargs):
+        # type: (Any, Any, Any, float, bool, Any) -> Any
         """
         Args:
             programName:
@@ -206,7 +268,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         taskparameters = {
             'command': 'StartITLProgram',
             'programName': programName,
-        }
+        }  # type: Dict[str, Any]
         if robotspeed is not None:
             taskparameters['robotspeed'] = robotspeed
         if robotaccelmult is not None:
@@ -215,6 +277,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def StopITLProgram(self, timeout=10, fireandforget=False, **kwargs):
+        # type: (float, bool, Any) -> Any
         """Stops the ITL program
 
         Args:
@@ -223,11 +286,12 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         """
         taskparameters = {
             'command': 'StopITLProgram',
-        }
+        }  # type: Dict[str, Any]
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def GenerateExecutionGraph(self, programName, commandTimeout=0.2, totalTimeout=1.0, timeout=10, fireandforget=False, **kwargs):
+        # type: (Any, Any, Any, float, bool, Any) -> Any
         """Generates a list of commands for the ITL program.
 
         Args:
@@ -242,11 +306,12 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             'programName': programName,
             'commandTimeout': commandTimeout,
             'totalTimeout': totalTimeout,
-        }
+        }  # type: Dict[str, Any]
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)
 
     def PopulateTargetInContainer(self, locationName, populateTargetUri, populateFnName, containerMetaData=None, timeout=20, **kwargs):
+        # type: (Any, Any, Any, Optional[Dict], float, Any) -> Any
         """Populates targets in the container using populateFn.
 
         Args:
@@ -261,7 +326,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
             'locationName': locationName,
             'populateTargetUri': populateTargetUri,
             'populateFnName': populateFnName,
-        }
+        }  # type: Dict[str, Any]
         if containerMetaData is not None:
             taskparameters['containerMetaData'] = containerMetaData
         taskparameters.update(kwargs)


### PR DESCRIPTION
Explicitly pass parameters instead of using kwags and add type annotations.

We're removing kwargs since these arguments are the only ones that the underlying planningclient accepts, and the function signature is uninformative otherwise.