### PR TITLE
Add robot planning functionality to the hand eye calibration client

### DIFF
--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -3,14 +3,14 @@
 # Mujin controller client for bin picking task
 
 # mujin imports
-from . import planningclient
+from .realtimerobotplanningclient import RealtimeRobotPlanningClient
 
 # logging
 import logging
 log = logging.getLogger(__name__)
 
 
-class HandEyeCalibrationPlanningClient(planningclient.PlanningClient):
+class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
     """Mujin planning client for the HandEyeCalibration task"""
 
     tasktype = 'handeyecalibration'
@@ -45,7 +45,6 @@ class HandEyeCalibrationPlanningClient(planningclient.PlanningClient):
     #
     # Commands
     #
-
 
     def ComputeCalibrationPoses(self, primarySensorSelectionInfo, secondarySensorSelectionInfos, numsamples, calibboardvisibility, calibboardLinkName=None, calibboardGeomName=None, timeout=3000, gridindex=None, **kwargs):
         """Compute a set of calibration poses that satisfy the angle constraints using latin hypercube sampling (or stratified sampling upon failure)


### PR DESCRIPTION
This enables the calibration orchestrator to use only one planning client, which seemed simpler than redesigning the way we do client pools to allow for two different planning clients.

(The calls are in the calibration manager.)