### PR TITLE
Fix planning client inits

### DIFF
--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -24,7 +24,7 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
 
     def __init__(
         self,
-        robotname,
+        robotname=None,
         robotspeed=None,
         robotaccelmult=None,
         envclearance=10.0,

--- a/python/mujinplanningclient/handeyecalibrationplanningclient.py
+++ b/python/mujinplanningclient/handeyecalibrationplanningclient.py
@@ -42,7 +42,7 @@ class HandEyeCalibrationPlanningClient(RealtimeRobotPlanningClient):
         callerid='',
         **ignoredArgs
     ):
-        # type: (str, Optional[float], Optional[float], float, Optional[str], int, int, float, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
+        # type: (Optional[str], Optional[float], Optional[float], float, Optional[str], int, int, float, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
         """Connects to the Mujin controller, initializes HandEyeCalibration task and sets up parameters
 
         Args:

--- a/python/mujinplanningclient/realtimeitl3planningclient.py
+++ b/python/mujinplanningclient/realtimeitl3planningclient.py
@@ -25,7 +25,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
 
     def __init__(
         self,
-        robotname='',
+        robotname=None,
         robotspeed=None,
         robotaccelmult=None,
         envclearance=10.0,
@@ -43,7 +43,7 @@ class RealtimeITL3PlanningClient(realtimerobotplanningclient.RealtimeRobotPlanni
         callerid='',
         **ignoredArgs
     ):
-        # type: (str, Optional[float], Optional[float], float, Optional[str], int, int, float, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
+        # type: (Optional[str], Optional[float], Optional[float], float, Optional[str], int, int, float, Optional[zmq.Context], Optional[str], str, str, str, str, str, str, Any) -> None
         """Connects to the Mujin controller, initializes RealtimeITL3 task and sets up parameters
 
         Args:


### PR DESCRIPTION
Set `robotname` default to `None`. Fixes client pool creation.