### PR TITLE
Fix changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,43 @@
-# 0.1.6 (2023-06-09)
+# Changelog
+
+## 0.1.6 (2023-06-09)
+
+### Changes
 
 - Fix `SetLogLevel` call in planningclient
 
-# 0.1.4 (2023-04-06)
+## 0.1.5 (2023-05-04)
+
+### Changes
+
+- Add `GetPublishedServerState` and `GetPublishedTaskState` functions.
+
+## 0.1.4 (2023-04-06)
+
+### Changes
 
 - Add `ZmqSubscriber`
 
+## 0.1.3 (2023-03-04)
 
-# 0.1.0 (2022-11-17)
+### Changes
+
+- Add `HasDetectionObstacles` function.
+
+## 0.1.2 (2023-02-21)
+
+### Changes
+
+- Add `GetLinkParentInfo` function.
+
+## 0.1.1 (2023-01-30)
+
+### Changes
+
+- Use sensor selections in calibration.
+
+## 0.1.0 (2022-11-17)
+
+### Changes
 
 - Port from mujincontrollerclientpy


### PR DESCRIPTION
Adjust changelog format. Missing entries are taken from commit messages via 

```
git rev-list --ancestry-path dc05515084e6a06b30e044e19fbcf225c7c82ef3^..4c9cb4dd8f6c63a197ba30b56186decaa3496cad | xargs git show
```