### PR TITLE
[Manual Recovery] Propagate packFormationParameters to planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add master functions TerminateSlaves, CancelSlaves, Quit
 
-## 0.3.2 (2024-03-11)
+## 0.4.0 (2024-03-12)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - Add master functions TerminateSlaves, CancelSlaves, Quit
 
+## 0.3.2 (2024-03-11)
+
+### Changes
+
+- When doing manual picking, propagate packFormationParameters to planning (instead of dynamicGoalGeneratorParameters).
+
 ## 0.3.1 (2024-02-28)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changes
 
-- When doing manual picking, propagate packFormationParameters to planning (instead of dynamicGoalGeneratorParameters).
+- [BREAKING] `ManuallyPlacePackItem` now takes the input argument `packFormationParameters` instead of `dynamicGoalGeneratorParameters`
 
 ## 0.3.1 (2024-02-28)
 

--- a/python/mujinplanningclient/binpickingplanningclient.py
+++ b/python/mujinplanningclient/binpickingplanningclient.py
@@ -652,8 +652,6 @@ class BinpickingPlanningClient(realtimerobotplanningclient.RealtimeRobotPlanning
             taskparameters['orderNumber'] = orderNumber
         if numLeftToPick is not None:
             taskparameters['numLeftToPick'] = numLeftToPick
-        if numLeftToPick is not None:
-            taskparameters['numLeftToPick'] = numLeftToPick
         if placedTargetPrefix:
             taskparameters['placedTargetPrefix'] = placedTargetPrefix
         if packFormationParameters is not None:

--- a/python/mujinplanningclient/binpickingplanningclient.py
+++ b/python/mujinplanningclient/binpickingplanningclient.py
@@ -628,7 +628,7 @@ class BinpickingPlanningClient(realtimerobotplanningclient.RealtimeRobotPlanning
         taskparameters.update(kwargs)
         return self.ExecuteCommand(taskparameters, fireandforget=fireandforget)
 
-    def ManuallyPlacePackItem(self, packFormationComputationResult=None, inputPartIndex=None, placeLocationNames=None, placedTargetPrefix=None, dynamicGoalsGeneratorParameters=None, orderNumber=None, numLeftToPick=None, timeout=10, fireandforget=False):
+    def ManuallyPlacePackItem(self, packFormationComputationResult=None, inputPartIndex=None, placeLocationNames=None, placedTargetPrefix=None, packFormationParameters=None, orderNumber=None, numLeftToPick=None, timeout=10, fireandforget=False):
         """Places an item according to the pack formation assuming the item is placed manually and updates robotbridge state
 
         Args:
@@ -656,6 +656,6 @@ class BinpickingPlanningClient(realtimerobotplanningclient.RealtimeRobotPlanning
             taskparameters['numLeftToPick'] = numLeftToPick
         if placedTargetPrefix:
             taskparameters['placedTargetPrefix'] = placedTargetPrefix
-        if dynamicGoalsGeneratorParameters is not None:
-            taskparameters['dynamicGoalsGeneratorParameters'] = dynamicGoalsGeneratorParameters
+        if packFormationParameters is not None:
+            taskparameters['packFormationParameters'] = packFormationParameters
         return self.ExecuteCommand(taskparameters, timeout=timeout, fireandforget=fireandforget)

--- a/python/mujinplanningclient/binpickingplanningclient.py
+++ b/python/mujinplanningclient/binpickingplanningclient.py
@@ -632,13 +632,13 @@ class BinpickingPlanningClient(realtimerobotplanningclient.RealtimeRobotPlanning
         """Places an item according to the pack formation assuming the item is placed manually and updates robotbridge state
 
         Args:
-            packFormationComputationResult:
-            inputPartIndex:
-            placeLocationNames:
-            placedTargetPrefix:
-            dynamicGoalsGeneratorParameters:
-            orderNumber:
-            numLeftToPick:
+            packFormationComputationResult (json): Pack formation that we try to follow.
+            inputPartIndex (int): Index of the item from packFormationComputationResult (1-based)
+            placeLocationNames (list(str)): Place location names of the order request.
+            placedTargetPrefix (str): Name prefix of items placed to the desired place location.
+            packFormationParameters (json): Placement parameters that should be used to generate final placement position of the item.
+            orderNumber (int, null): Number of items that should be placed as a part of the order.
+            numLeftToPick (int, null): Number of items remaining to be picked as a part of the order.
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
             fireandforget (bool, optional): If True, does not wait for the command to finish and returns immediately. The command remains queued on the server. (Default: False)
         """

--- a/python/mujinplanningclient/binpickingplanningclient.py
+++ b/python/mujinplanningclient/binpickingplanningclient.py
@@ -637,8 +637,8 @@ class BinpickingPlanningClient(realtimerobotplanningclient.RealtimeRobotPlanning
             placeLocationNames (list(str)): Place location names of the order request.
             placedTargetPrefix (str): Name prefix of items placed to the desired place location.
             packFormationParameters (json): Placement parameters that should be used to generate final placement position of the item.
-            orderNumber (int, null): Number of items that should be placed as a part of the order.
-            numLeftToPick (int, null): Number of items remaining to be picked as a part of the order.
+            orderNumber (int, optional): Number of items that should be placed as a part of the order.
+            numLeftToPick (int, optional): Number of items remaining to be picked as a part of the order.
             timeout (float, optional): Time in seconds after which the command is assumed to have failed. (Default: 10)
             fireandforget (bool, optional): If True, does not wait for the command to finish and returns immediately. The command remains queued on the server. (Default: False)
         """

--- a/python/mujinplanningclient/version.py
+++ b/python/mujinplanningclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.2'
+__version__ = '0.4.0'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinplanningclient/version.py
+++ b/python/mujinplanningclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
With the new structure of parameters, we need to propagate the packFormationParameters structure to planning when doing manual picking.